### PR TITLE
Caught up release notes in preperation for 3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# ShakeIt Photo ChangeLog
+
+## Development (3.2.6)
+
+### Fixes
+
+- **Fix broken link to the Shake It Photo Tutorial.** Upon initial
+  installation, the app would link to a tutorial. However, this link was
+  broken. **Test this by** doing a fresh installation of
+  ShakeIt and confirming that an option to view a tutorial video is provided,
+  and that tapping the offered tutorial opens a video.  Thank you to [Tom Lee]
+  for [his generous
+  contribution](https://github.com/zinc-collective/mp-shake-it-photo/pull/10).
+
+
+### Enhancements
+
+- **Improve support for larger sized and notched screens.** Since the
+  release of the the larger iPhone screens, ShakeIt Photo has had gaps
+  between the application interface and the larger devices bezels. With
+  the iPhone X, ShakeIt Photo had not taken into account the "Notch" in our
+  user interface design. **Test this by** using ShakeIt Photo as
+  usual, and keep an eye out for places where the App UI is occluded by
+  hardware or OS UI elements, or where there is significant whitespace (or
+  blackspace) between applicaiton UI elements and your devices top or
+  bottom edge. Thank you to [Tom Lee] for [his generous
+  contribution](https://github.com/zinc-collective/mp-shake-it-photo/pull/12)
+
+### Changes
+
+- **Adopt the Prosperity License and publicly release the source code.** The
+  Cooperative has decided that it is safe for us to release ShakeIt Photo's
+  source code publicly under a non-commercial license, so that folks who want to
+  perform maintenance, submit enhancements, or fix issues can do so. Thank you to
+  [Zee Spencer] for [his generous
+  contribution](https://github.com/zinc-collective/mp-shake-it-photo/commit/c52c73f2cda24385acd977b6cefe0f97b63087a8)
+
+- **Apply changes to comply with Polaroid brand guidelines.** As part of our
+  agreement with Polaroid, we must comply with their brand regulations. Thank
+  you to [Tom Lee] for [his generous
+  contribution](https://github.com/zinc-collective/mp-shake-it-photo/pull/2)
+
+
+[Tom Lee]:https://github.com/user512
+[Zee Spencer]:https://www.zeespencer.com

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # ShakeItPhoto
 
-## Contributing
 
-### Prerequisite
+## Become a Tester
+
+If you would like to provide feedback on ShakeIt Photo's upcoming releases,
+please [let us know](http://www.momentpark.com/contact-us) and we will invite
+you to Test Flight.
+
+You can [find a summary of the latest changes in our changelog](./CHANGELOG.md)
+
+## Become a Contributor
+
+Familiarize yourself with [Zinc's guide to becoming a
+contributor](https://www.zinc.coop/contributing/) and read on!
+
+### Prerequisites
 
 [Download the GoogleService-Info.plist from the Firebase console] and place it
 in the project root directory. See [Add Firebase to your iOS project] for more


### PR DESCRIPTION
See:
- https://github.com/zinc-collective/mp-shake-it-photo/issues/9
- https://github.com/zinc-collective/mp-shake-it-photo/issues/7
- https://github.com/zinc-collective/mp-shake-it-photo/issues/3

I've written out a test plan in with the release notes; in the hopes
that when we release the next test-flight builds release notes and test
instructions we can copy-paste from the CHANGELOG.md file.

I've also sprouted sections in the README for Becoming a Tester 
and Becoming a Contributor

I intend to link to this from the July Community announcement.